### PR TITLE
Check for BL before passthrough setup

### DIFF
--- a/src/serial/openvtx.ts
+++ b/src/serial/openvtx.ts
@@ -15,6 +15,38 @@ const RST_MAGIC = ["R".charCodeAt(0), "S".charCodeAt(0), "T".charCodeAt(0)];
 export class OpenVTX {
   private constructor(private serial: Serial) {}
 
+  public static async listenForBootloader(serial: Serial, useSmartAudio: Boolean) {
+
+    const ovtx = new OpenVTX(serial);
+
+    if (useSmartAudio){
+      await ovtx.serial.connect({
+        baudRate: 4800,
+        stopBits: 2,
+      });
+    }
+    
+    let tries = 0;
+    while (tries <= 3) {
+      if (tries == 3) {
+        throw new Error("");
+      }
+
+      try {
+        const seq = await ovtx.serial.read(3, 1000);
+        if (String.fromCharCode(...seq) == "CCC") {
+          break;
+        }
+      } catch (e) {
+        if (e != "timeout") {
+          throw e;
+        }
+      }
+
+      tries++;
+    }
+  }
+
   public static async resetToBootloader(serial: Serial, vtxType: VTXType) {
     const ovtx = new OpenVTX(serial);
 

--- a/src/serial/openvtx.ts
+++ b/src/serial/openvtx.ts
@@ -28,9 +28,14 @@ export class OpenVTX {
     
     let tries = 0;
     while (tries <= 3) {
+
+      await ovtx.serial.flush();
+
       if (tries == 3) {
         throw new Error("");
       }
+
+      Log.info("listening", "attempt #", tries + 1, "/ 3");
 
       try {
         const seq = await ovtx.serial.read(3, 1000);

--- a/src/views/FlashView.vue
+++ b/src/views/FlashView.vue
@@ -162,12 +162,12 @@ async function flashFile(
   let vtxType = VTXType.Unknown;
 
   try{
-    Log.info("listening", "Is the VTx already in bootloader mode? Checking with SmartAudio settings...");
+    Log.info("listening", "Is the VTx already in bootloader mode? Checking with SmartAudio settings.");
     await OpenVTX.listenForBootloader(serial, true);
     bootloaderActive = true;
-    Log.info("listening", "Yes.");
-  } catch (err) {
-    Log.debug("listening", "Nope.");
+    Log.info("listening", "Bootloader found.");
+    } catch (err) {
+    Log.debug("listening", "Bootloader not found.");
   }
   
   if (!bootloaderActive){
@@ -183,12 +183,12 @@ async function flashFile(
 
   if (!bootloaderActive){
     try{
-      Log.info("listening", "Is the VTx already in bootloader mode?...");
+      Log.info("listening", "Is the VTx already in bootloader mode? Checking with SmartAudio settings.");
       await OpenVTX.listenForBootloader(serial, false);
       bootloaderActive = true;
-    Log.info("listening", "Yes.");
-  } catch (err) {
-    Log.debug("listening", "Nope.");
+      Log.info("listening", "Bootloader found.");
+    } catch (err) {
+      Log.debug("listening", "Bootloader not found.");
     }
   }
 

--- a/src/views/FlashView.vue
+++ b/src/views/FlashView.vue
@@ -158,23 +158,49 @@ async function flashFile(
   firmware: Uint8Array,
   progressCallback: (p: number) => void
 ) {
-  Log.info("flash", "attempting msp passthrough");
+  let bootloaderActive = false;
   let vtxType = VTXType.Unknown;
-  try {
-    vtxType = await MSPPassthrough.enable(serial);
-    Log.info("flash", "detected vtx type", vtxType);
+
+  try{
+    Log.info("listening", "Is the VTx already in bootloader mode? Checking with SmartAudio settings...");
+    await OpenVTX.listenForBootloader(serial, true);
+    bootloaderActive = true;
+    Log.info("listening", "Yes.");
   } catch (err) {
-    Log.warn("flash", "passthrough failed");
-    Log.debug("flash", err);
+    Log.debug("listening", "Nope.");
+  }
+  
+  if (!bootloaderActive){
+    try {
+      Log.info("flash", "attempting msp passthrough");
+      vtxType = await MSPPassthrough.enable(serial);
+      Log.info("flash", "detected vtx type", vtxType);
+    } catch (err) {
+      Log.warn("flash", "passthrough failed");
+      Log.debug("flash", err);
+    }
   }
 
-  try {
-    Log.info("flash", "attempting to reboot into bootloader");
-    await OpenVTX.resetToBootloader(serial, vtxType);
-    Log.info("flash", "detected bootloader");
+  if (!bootloaderActive){
+    try{
+      Log.info("listening", "Is the VTx already in bootloader mode?...");
+      await OpenVTX.listenForBootloader(serial, false);
+      bootloaderActive = true;
+    Log.info("listening", "Yes.");
   } catch (err) {
-    Log.warn("flash", err);
-    return;
+    Log.debug("listening", "Nope.");
+    }
+  }
+
+  if (!bootloaderActive){
+    try {
+      Log.info("flash", "attempting to reboot into bootloader");
+      await OpenVTX.resetToBootloader(serial, vtxType);
+      Log.info("flash", "detected bootloader");
+    } catch (err) {
+      Log.warn("flash", err);
+      return;
+    }
   }
 
   Log.info("flash", "flashing", firmware.byteLength, "bytes");


### PR DESCRIPTION
This change is required for the new bootloader.  The Configurator will now listen for the sync packet before setting up passthrough or resetting the VTx to BL mode.  Doing either of these can cause xmodem to jump to the main app and leave BL mode.

Requires https://github.com/OpenVTx/OpenVTx_bootloader/pull/9